### PR TITLE
feat: add hero persistence and hotkey fix

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -27,13 +27,19 @@ namespace Owmeta
         private bool _mutexOwned;
         private bool _isShowingLogin;
         private const string MutexName = "Global\\OWMETA_HUD_INSTANCE";
-        private const string ApiBaseUrl = "https://api.owmeta.io";
+        private static string ApiBaseUrl = "https://api.owmeta.io";
 
 #if DEBUG
         public const bool DEV_MODE = true;  // Set this to false to test normal mode while debugging
 #else
         public const bool DEV_MODE = false;
 #endif
+
+        // CLI test mode
+        public static bool AutoTestMode { get; private set; }
+        public static int AutoTestIntervalSeconds { get; private set; } = 10;
+        public static string? AutoTestDir { get; private set; }
+        public static string? OverrideToken { get; private set; }
 
         protected override void OnStartup(StartupEventArgs e)
         {
@@ -343,23 +349,82 @@ namespace Owmeta
 
         private void ParseSettingsArgs(string[] args)
         {
-            foreach (var arg in args)
+            for (int i = 0; i < args.Length; i++)
             {
-                if (arg.StartsWith("--min-score-f2=", StringComparison.OrdinalIgnoreCase))
+                if (args[i].StartsWith("--min-score-f2=", StringComparison.OrdinalIgnoreCase))
                 {
-                    if (int.TryParse(arg.Substring("--min-score-f2=".Length), out int value))
+                    if (int.TryParse(args[i].Substring("--min-score-f2=".Length), out int value))
                     {
                         AppSettings.Instance.MinScoreF2 = value;
                         AppSettings.Instance.Save();
                     }
                 }
-                else if (arg.StartsWith("--min-score-f3=", StringComparison.OrdinalIgnoreCase))
+                else if (args[i].StartsWith("--min-score-f3=", StringComparison.OrdinalIgnoreCase))
                 {
-                    if (int.TryParse(arg.Substring("--min-score-f3=".Length), out int value))
+                    if (int.TryParse(args[i].Substring("--min-score-f3=".Length), out int value))
                     {
                         AppSettings.Instance.MinScoreF3 = value;
                         AppSettings.Instance.Save();
                     }
+                }
+                else if (args[i].StartsWith("--api-url=", StringComparison.OrdinalIgnoreCase))
+                {
+                    ApiBaseUrl = args[i].Substring("--api-url=".Length);
+                    Logger.Log($"API URL overridden to: {ApiBaseUrl}");
+                }
+                else if (args[i] == "--api-url" && i + 1 < args.Length)
+                {
+                    ApiBaseUrl = args[++i];
+                    Logger.Log($"API URL overridden to: {ApiBaseUrl}");
+                }
+                else if (args[i] == "--auto-test")
+                {
+                    AutoTestMode = true;
+                    Logger.Log("Auto-test mode enabled");
+                }
+                else if (args[i].StartsWith("--interval=", StringComparison.OrdinalIgnoreCase))
+                {
+                    if (int.TryParse(args[i].Substring("--interval=".Length), out int value))
+                    {
+                        AutoTestIntervalSeconds = value;
+                    }
+                }
+                else if (args[i] == "--interval" && i + 1 < args.Length)
+                {
+                    if (int.TryParse(args[++i], out int value))
+                    {
+                        AutoTestIntervalSeconds = value;
+                    }
+                }
+                else if (args[i].StartsWith("--dir=", StringComparison.OrdinalIgnoreCase))
+                {
+                    AutoTestDir = args[i].Substring("--dir=".Length);
+                }
+                else if (args[i] == "--dir" && i + 1 < args.Length)
+                {
+                    AutoTestDir = args[++i];
+                }
+                else if (args[i] == "--test-token")
+                {
+                    OverrideToken = Environment.GetEnvironmentVariable("OWMETA_TEST_TOKEN") ?? "";
+                    if (string.IsNullOrEmpty(OverrideToken))
+                    {
+                        Logger.Log("--test-token: OWMETA_TEST_TOKEN env var not set");
+                    }
+                    else
+                    {
+                        Logger.Log("Using test token from OWMETA_TEST_TOKEN env var");
+                    }
+                }
+                else if (args[i].StartsWith("--token=", StringComparison.OrdinalIgnoreCase))
+                {
+                    OverrideToken = args[i].Substring("--token=".Length);
+                    Logger.Log("Using custom override token");
+                }
+                else if (args[i] == "--token" && i + 1 < args.Length)
+                {
+                    OverrideToken = args[++i];
+                    Logger.Log("Using custom override token");
                 }
             }
         }

--- a/Display/DataFreshnessIndicator.xaml.cs
+++ b/Display/DataFreshnessIndicator.xaml.cs
@@ -15,6 +15,7 @@ namespace Owmeta.Display
         private static readonly SolidColorBrush StaleBrush = new(Color.FromRgb(0xF5, 0x9E, 0x0B));    // Yellow/Amber - 1-3 min
         private static readonly SolidColorBrush OldBrush = new(Color.FromRgb(0xEF, 0x44, 0x44));      // Red - > 3 min
         private static readonly SolidColorBrush AnalyzingBrush = new(Color.FromRgb(0x3B, 0x82, 0xF6)); // Blue
+        private static readonly SolidColorBrush PartialBrush = new(Color.FromRgb(0x38, 0xBD, 0xF8));  // Light blue
 
         static DataFreshnessIndicator()
         {
@@ -23,6 +24,7 @@ namespace Owmeta.Display
             StaleBrush.Freeze();
             OldBrush.Freeze();
             AnalyzingBrush.Freeze();
+            PartialBrush.Freeze();
         }
 
         public DataFreshnessIndicator()
@@ -118,6 +120,13 @@ namespace Owmeta.Display
         {
             StatusText.Text = "Using cached data";
             StatusDot.Fill = StaleBrush;
+        }
+
+        public void SetPartialUpdate(int persistedCount)
+        {
+            _lastUpdateTime = DateTime.Now;
+            StatusText.Text = $"Updated ({persistedCount} heroes from memory)";
+            StatusDot.Fill = PartialBrush;
         }
     }
 }

--- a/Display/OverlayWindow.xaml.cs
+++ b/Display/OverlayWindow.xaml.cs
@@ -148,6 +148,10 @@ namespace Owmeta.Display
         private Visibility _compVisibilityBeforeScreenshot;
         private int _screenshotKeyPressed; // 0 = not pressed, 1 = pressed (use Interlocked for thread safety)
 
+        // Track hotkey pressed state to prevent flickering from key repeat
+        private volatile bool _swapKeyHeld;
+        private volatile bool _teamKeyHeld;
+
         public OverlayWindow(bool devMode)
         {
             _devMode = devMode;
@@ -304,54 +308,28 @@ namespace Owmeta.Display
 
             var settings = AppSettings.Instance;
 
-            // Update Swap Suggestions hotkey
-            if (!KeyHelper.IsMouseButton(settings.SwapSuggestionsKey))
-            {
-                if (_swapHotkeyRegistered && _currentSwapKey != settings.SwapSuggestionsKey)
-                {
-                    UnregisterHotKey(_windowHandle, SWAP_HOTKEY_ID);
-                    _swapHotkeyRegistered = false;
-                }
-
-                if (!_swapHotkeyRegistered && settings.SwapSuggestionsKey > 0)
-                {
-                    RegisterHotKey(_windowHandle, SWAP_HOTKEY_ID, 0, (uint)settings.SwapSuggestionsKey);
-                    _swapHotkeyRegistered = true;
-                    _currentSwapKey = settings.SwapSuggestionsKey;
-                    Logger.Log($"Swap hotkey registered: {KeyHelper.GetKeyName(settings.SwapSuggestionsKey)}");
-                }
-            }
-            else if (_swapHotkeyRegistered)
+            // Unregister old hotkeys if they were registered (we now use keyboard hook instead)
+            if (_swapHotkeyRegistered)
             {
                 UnregisterHotKey(_windowHandle, SWAP_HOTKEY_ID);
                 _swapHotkeyRegistered = false;
             }
-
-            // Update Team Composition hotkey
-            if (!KeyHelper.IsMouseButton(settings.TeamCompositionKey))
-            {
-                if (_teamHotkeyRegistered && _currentTeamKey != settings.TeamCompositionKey)
-                {
-                    UnregisterHotKey(_windowHandle, TEAM_HOTKEY_ID);
-                    _teamHotkeyRegistered = false;
-                }
-
-                if (!_teamHotkeyRegistered && settings.TeamCompositionKey > 0)
-                {
-                    RegisterHotKey(_windowHandle, TEAM_HOTKEY_ID, 0, (uint)settings.TeamCompositionKey);
-                    _teamHotkeyRegistered = true;
-                    _currentTeamKey = settings.TeamCompositionKey;
-                    Logger.Log($"Team hotkey registered: {KeyHelper.GetKeyName(settings.TeamCompositionKey)}");
-                }
-            }
-            else if (_teamHotkeyRegistered)
+            if (_teamHotkeyRegistered)
             {
                 UnregisterHotKey(_windowHandle, TEAM_HOTKEY_ID);
                 _teamHotkeyRegistered = false;
             }
 
-            // Update mouse hook
+            // Track current keys for keyboard hook
+            _currentSwapKey = settings.SwapSuggestionsKey;
+            _currentTeamKey = settings.TeamCompositionKey;
+            Logger.Log($"Hotkeys updated: Swap={KeyHelper.GetKeyName(settings.SwapSuggestionsKey)}, Team={KeyHelper.GetKeyName(settings.TeamCompositionKey)}");
+
+            // Update mouse hook for mouse button bindings
             SetupMouseHookIfNeeded();
+
+            // Update keyboard hook for keyboard bindings
+            UpdateScreenshotHotkeyRegistration();
         }
 
         private IntPtr FindOverwatchWindow()
@@ -435,8 +413,7 @@ namespace Owmeta.Display
 
             if (_windowHandle != IntPtr.Zero)
             {
-                UnregisterHotKey(_windowHandle, SWAP_HOTKEY_ID);
-                UnregisterHotKey(_windowHandle, TEAM_HOTKEY_ID);
+                // F2/F3 now use keyboard hook, only F5/F6 use RegisterHotKey
                 if (_devMode)
                 {
                     UnregisterHotKey(_windowHandle, F5_HOTKEY_ID);
@@ -451,26 +428,29 @@ namespace Owmeta.Display
             if (_windowHandle == IntPtr.Zero) return;
 
             var settings = AppSettings.Instance;
-            bool shouldBeEnabled = settings.TabScreenshotEnabled && settings.ScreenshotKey > 0;
+            bool needScreenshotHook = settings.TabScreenshotEnabled && settings.ScreenshotKey > 0;
+            bool needSwapHook = !KeyHelper.IsMouseButton(settings.SwapSuggestionsKey) && settings.SwapSuggestionsKey > 0;
+            bool needTeamHook = !KeyHelper.IsMouseButton(settings.TeamCompositionKey) && settings.TeamCompositionKey > 0;
+            bool shouldBeEnabled = needScreenshotHook || needSwapHook || needTeamHook;
 
             if (shouldBeEnabled && _keyboardHookId == IntPtr.Zero)
             {
-                // Install keyboard hook to detect screenshot key press/release without blocking
+                // Install keyboard hook to detect key press/release without blocking
                 _keyboardProc = KeyboardHookCallback;
                 _keyboardHookId = SetWindowsHookExKeyboard(WH_KEYBOARD_LL, _keyboardProc, GetModuleHandle(null), 0);
                 _currentScreenshotKey = settings.ScreenshotKey;
-                Logger.Log($"Screenshot keyboard hook installed for: {KeyHelper.GetKeyName(settings.ScreenshotKey)}");
+                Logger.Log($"Keyboard hook installed for hotkeys");
             }
             else if (!shouldBeEnabled && _keyboardHookId != IntPtr.Zero)
             {
                 RemoveKeyboardHook();
-                Logger.Log("Screenshot keyboard hook removed");
+                Logger.Log("Keyboard hook removed");
             }
-            else if (shouldBeEnabled && _currentScreenshotKey != settings.ScreenshotKey)
+
+            // Update tracked keys
+            if (shouldBeEnabled)
             {
-                // Key changed, just update the tracked key (hook handles all keys)
                 _currentScreenshotKey = settings.ScreenshotKey;
-                Logger.Log($"Screenshot key changed to: {KeyHelper.GetKeyName(settings.ScreenshotKey)}");
             }
         }
 
@@ -566,8 +546,15 @@ namespace Owmeta.Display
                     SwapSuggestionsPanel.UpdateSuggestions(_matchState.PlayerHero, _blueTeamAnalysis, _matchState.Map);
 
                     // Show appropriate status indicator
-                    if (usingCachedData)
-                        DataFreshnessIndicator.SetStaleWarning();
+                    // Always mark as updated on successful API response — even if some heroes are Unknown.
+                    // The hero panels still fall back to cached data internally, but the indicator
+                    // reflects that the server responded successfully.
+                    bool hasPersistedSlots = response.PersistedBlueTeamSlots.Count > 0 ||
+                                             response.PersistedRedTeamSlots.Count > 0;
+
+                    if (hasPersistedSlots)
+                        DataFreshnessIndicator.SetPartialUpdate(
+                            response.PersistedBlueTeamSlots.Count + response.PersistedRedTeamSlots.Count);
                     else
                         DataFreshnessIndicator.MarkUpdated();
                 }
@@ -587,7 +574,6 @@ namespace Owmeta.Display
 
             return data
                 .Where(kvp => kvp.Key != HeroName.Unknown &&
-                              kvp.Key != HeroName.Hidden &&
                               kvp.Key != HeroName.NameUnspecified)
                 .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
         }
@@ -735,7 +721,7 @@ namespace Owmeta.Display
                 var hookStruct = Marshal.PtrToStructure<KBDLLHOOKSTRUCT>(lParam);
                 int vkCode = (int)hookStruct.vkCode;
 
-                // Only handle our screenshot key
+                // Handle screenshot key
                 if (vkCode == _currentScreenshotKey)
                 {
                     if (wParam == (IntPtr)WM_KEYDOWN)
@@ -782,6 +768,34 @@ namespace Owmeta.Display
                         }
                     }
                 }
+
+                // Handle swap key (F2) - track held state to prevent flicker from key repeat
+                if (vkCode == _currentSwapKey && !KeyHelper.IsMouseButton(_currentSwapKey))
+                {
+                    if (wParam == (IntPtr)WM_KEYDOWN && !_swapKeyHeld)
+                    {
+                        _swapKeyHeld = true;
+                        Dispatcher.BeginInvoke(new Action(() => ToggleVisibility()));
+                    }
+                    else if (wParam == (IntPtr)WM_KEYUP)
+                    {
+                        _swapKeyHeld = false;
+                    }
+                }
+
+                // Handle team key (F3) - track held state to prevent flicker from key repeat
+                if (vkCode == _currentTeamKey && !KeyHelper.IsMouseButton(_currentTeamKey))
+                {
+                    if (wParam == (IntPtr)WM_KEYDOWN && !_teamKeyHeld)
+                    {
+                        _teamKeyHeld = true;
+                        Dispatcher.BeginInvoke(new Action(() => ToggleCompositionDashboard()));
+                    }
+                    else if (wParam == (IntPtr)WM_KEYUP)
+                    {
+                        _teamKeyHeld = false;
+                    }
+                }
             }
 
             // IMPORTANT: Always pass the key to the next hook so it reaches the game
@@ -792,14 +806,7 @@ namespace Owmeta.Display
         {
             switch (msg)
             {
-                case WM_HOTKEY when wParam.ToInt32() == SWAP_HOTKEY_ID:
-                    ToggleVisibility();
-                    handled = true;
-                    break;
-                case WM_HOTKEY when wParam.ToInt32() == TEAM_HOTKEY_ID:
-                    ToggleCompositionDashboard();
-                    handled = true;
-                    break;
+                // F2/F3 hotkeys now handled via keyboard hook to prevent flicker from key repeat
                 case WM_HOTKEY when wParam.ToInt32() == F5_HOTKEY_ID:
                     Logger.Log("[DEV] F5 pressed - previous screenshot");
                     _screenshotService?.PreviousScreenshot();

--- a/Model/ScreenshotProcessingResponse.cs
+++ b/Model/ScreenshotProcessingResponse.cs
@@ -8,6 +8,8 @@ namespace Owmeta.Model
         public required MatchState MatchState { get; set; }
         public required Dictionary<HeroName, HeroAnalysis> BlueTeamAnalysis { get; set; }
         public required Dictionary<HeroName, HeroAnalysis> RedTeamAnalysis { get; set; }
+        public List<string> PersistedBlueTeamSlots { get; set; } = new();
+        public List<string> PersistedRedTeamSlots { get; set; } = new();
     }
 
     public class ScreenshotProcessingResponseConverter : JsonConverter
@@ -82,6 +84,14 @@ namespace Owmeta.Model
                 }
             }
 
+            var persistedBlue = jo["persistedBlueTeamSlots"] as JArray;
+            if (persistedBlue != null)
+                response.PersistedBlueTeamSlots = persistedBlue.Select(t => t.ToString()).ToList();
+
+            var persistedRed = jo["persistedRedTeamSlots"] as JArray;
+            if (persistedRed != null)
+                response.PersistedRedTeamSlots = persistedRed.Select(t => t.ToString()).ToList();
+
             return response;
         }
 
@@ -123,6 +133,11 @@ namespace Owmeta.Model
             matchStateAnalysis["redTeamAnalysis"] = redTeam;
 
             jo["matchStateAnalysis"] = matchStateAnalysis;
+
+            if (response.PersistedBlueTeamSlots?.Count > 0)
+                jo["persistedBlueTeamSlots"] = new JArray(response.PersistedBlueTeamSlots);
+            if (response.PersistedRedTeamSlots?.Count > 0)
+                jo["persistedRedTeamSlots"] = new JArray(response.PersistedRedTeamSlots);
 
             jo.WriteTo(writer);
         }

--- a/Services/ApiService.cs
+++ b/Services/ApiService.cs
@@ -19,18 +19,36 @@ namespace Owmeta.Services
         private Timer? _tokenRefreshTimer;
         private bool _disposed;
         private bool _sessionExpiredFired;
+        private MatchState? _lastMatchState;
 
         // Event fired when session expires and re-login is required
         public event EventHandler? SessionExpired;
+
+        private readonly bool _useOverrideToken;
 
         public ApiService(string apiBaseUrl, KeycloakAuth keycloakAuth)
         {
             httpClient = new HttpClient { BaseAddress = new Uri(apiBaseUrl) };
             this.keycloakAuth = keycloakAuth;
+
+            // If an override token is set, use it directly (for local testing with -sso-unsafe)
+            if (!string.IsNullOrEmpty(App.OverrideToken))
+            {
+                accessToken = App.OverrideToken;
+                _useOverrideToken = true;
+                tokenExpiryTime = DateTime.UtcNow.AddHours(24); // Fake long expiry
+                Logger.Log("ApiService using override token - Keycloak auth bypassed");
+            }
         }
 
         public async Task<bool> LoadAndValidateTokens()
         {
+            if (_useOverrideToken)
+            {
+                Logger.Log("Override token active - skipping Keycloak validation");
+                return true;
+            }
+
             if (!System.IO.File.Exists(tokenFileName))
                 return false;
 
@@ -243,8 +261,8 @@ namespace Owmeta.Services
                 throw new UnauthorizedException("No access token available");
             }
 
-            // Pre-emptively refresh token if it's about to expire
-            if (IsTokenExpiredOrExpiringSoon())
+            // Skip token refresh for override tokens (local testing)
+            if (!_useOverrideToken && IsTokenExpiredOrExpiringSoon())
             {
                 var refreshed = await RefreshAndValidateToken();
                 if (!refreshed)
@@ -255,14 +273,47 @@ namespace Owmeta.Services
                 }
             }
 
-            return await SendScreenshotRequest(screenshotBase64, retryOnUnauthorized: true);
+            return await SendScreenshotRequest(screenshotBase64, retryOnUnauthorized: !_useOverrideToken);
+        }
+
+        private static object? SerializeMatchState(MatchState? matchState)
+        {
+            if (matchState == null) return null;
+            return new
+            {
+                blue_team = matchState.BlueTeam != null ? new
+                {
+                    tank = (int)matchState.BlueTeam.Tank,
+                    damage1 = (int)matchState.BlueTeam.Damage1,
+                    damage2 = (int)matchState.BlueTeam.Damage2,
+                    support1 = (int)matchState.BlueTeam.Support1,
+                    support2 = (int)matchState.BlueTeam.Support2
+                } : null,
+                red_team = matchState.RedTeam != null ? new
+                {
+                    tank = (int)matchState.RedTeam.Tank,
+                    damage1 = (int)matchState.RedTeam.Damage1,
+                    damage2 = (int)matchState.RedTeam.Damage2,
+                    support1 = (int)matchState.RedTeam.Support1,
+                    support2 = (int)matchState.RedTeam.Support2
+                } : null,
+                player_hero = (int)matchState.PlayerHero,
+                map = (int)matchState.Map
+            };
         }
 
         private async Task<ScreenshotProcessingResponse?> SendScreenshotRequest(string screenshotBase64, bool retryOnUnauthorized)
         {
             string formattedBase64 = $"data:image/jpeg;base64,{screenshotBase64}";
-            var input = new { screenshot_base64 = formattedBase64, use_websocket = false };
-            var content = new StringContent(JsonConvert.SerializeObject(input), System.Text.Encoding.UTF8, "application/json");
+            var input = new
+            {
+                screenshot_base64 = formattedBase64,
+                use_websocket = false,
+                previous_match_state = SerializeMatchState(_lastMatchState)
+            };
+            var serializedInput = JsonConvert.SerializeObject(input);
+            Logger.Log($"Sending request with previous_match_state: {(_lastMatchState != null ? "present" : "null")}");
+            var content = new StringContent(serializedInput, System.Text.Encoding.UTF8, "application/json");
 
             httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
             var response = await httpClient.PostAsync("/process-screenshot", content);
@@ -284,6 +335,8 @@ namespace Owmeta.Services
                 {
                     throw new ApiException("Failed to deserialize screenshot processing response");
                 }
+                _lastMatchState = result.MatchState;
+                Logger.Log($"Response persisted slots: blue={result.PersistedBlueTeamSlots.Count}, red={result.PersistedRedTeamSlots.Count}");
                 return result;
             }
 
@@ -325,6 +378,7 @@ namespace Owmeta.Services
                 accessToken = null;
                 refreshToken = null;
                 tokenExpiryTime = null;
+                _lastMatchState = null;
             }
             catch (Exception ex)
             {

--- a/Services/IconUtils.cs
+++ b/Services/IconUtils.cs
@@ -30,6 +30,7 @@ namespace Owmeta.Services
                 HeroName.JunkerQueen => "junker-queen",
                 HeroName.WreckingBall => "wrecking-ball",
                 HeroName.Dva => "dva",
+                HeroName.JetpackCat => "jetpack-cat",
                 _ => heroName.ToString().ToLower().Replace("_", "-")
             };
         }

--- a/Services/ScreenshotMonitoringService.cs
+++ b/Services/ScreenshotMonitoringService.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using Owmeta.Model;
+using System.Diagnostics;
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.IO;
@@ -60,7 +61,14 @@ namespace Owmeta.Services
             // In dev mode, process the latest file immediately
             if (App.DEV_MODE)
             {
-                ProcessLatestScreenshotForDev(bnetPath);
+                if (App.AutoTestMode)
+                {
+                    RunAutoTest(bnetPath);
+                }
+                else
+                {
+                    ProcessLatestScreenshotForDev(bnetPath);
+                }
             }
         }
 
@@ -119,6 +127,111 @@ namespace Owmeta.Services
                 Logger.Log($"[DEV]   1. Create folder: {devScreenshotsPath}");
                 Logger.Log($"[DEV]   2. Put an Overwatch Tab screen screenshot (.jpg or .png) in it");
                 Logger.Log($"[DEV]   OR use screenshots from: {bnetPath}");
+            }
+        }
+
+        private void RunAutoTest(string bnetPath)
+        {
+            string screenshotsPath = App.AutoTestDir ?? bnetPath;
+
+            if (!Directory.Exists(screenshotsPath))
+            {
+                Logger.Log($"[AUTO-TEST] Screenshot directory not found: {screenshotsPath}");
+                return;
+            }
+
+            LoadAllScreenshots(screenshotsPath);
+            Logger.Log($"[AUTO-TEST] Found {_allScreenshots.Count} screenshots in {screenshotsPath}");
+            Logger.Log($"[AUTO-TEST] Processing newest first, {App.AutoTestIntervalSeconds}s interval");
+
+            _ = Task.Run(async () =>
+            {
+                var stopwatch = new Stopwatch();
+                for (int i = 0; i < _allScreenshots.Count; i++)
+                {
+                    var file = _allScreenshots[i];
+                    var fileName = Path.GetFileName(file);
+
+                    Logger.Log($"\n[AUTO-TEST] === [{i + 1}/{_allScreenshots.Count}] {fileName} ===");
+
+                    try
+                    {
+                        using var image = Image.FromFile(file);
+                        using var ms = new MemoryStream();
+                        Logger.Log($"[AUTO-TEST] Image: {image.Width}x{image.Height}");
+                        image.Save(ms, System.Drawing.Imaging.ImageFormat.Jpeg);
+                        var base64String = Convert.ToBase64String(ms.ToArray());
+                        Logger.Log($"[AUTO-TEST] Sending {ms.Length} bytes...");
+
+                        stopwatch.Restart();
+
+                        synchronizationContext.Post(_ =>
+                        {
+                            AnalysisStarted?.Invoke(this, EventArgs.Empty);
+                        }, null);
+
+                        var response = await apiService.SendScreenshotToServer(base64String);
+                        stopwatch.Stop();
+
+                        if (response != null)
+                        {
+                            LogAutoTestResponse(response, stopwatch.ElapsedMilliseconds);
+                            synchronizationContext.Post(_ =>
+                            {
+                                ScreenshotProcessed?.Invoke(this, response);
+                            }, null);
+                        }
+                        else
+                        {
+                            Logger.Log($"[AUTO-TEST] NULL response ({stopwatch.ElapsedMilliseconds}ms)");
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Log($"[AUTO-TEST] ERROR: {ex.Message}");
+                        synchronizationContext.Post(_ =>
+                        {
+                            AnalysisError?.Invoke(this, ex.Message);
+                        }, null);
+                    }
+
+                    if (i < _allScreenshots.Count - 1)
+                    {
+                        Logger.Log($"[AUTO-TEST] Waiting {App.AutoTestIntervalSeconds}s...");
+                        await Task.Delay(App.AutoTestIntervalSeconds * 1000);
+                    }
+                }
+                Logger.Log($"\n[AUTO-TEST] === Done ({_allScreenshots.Count} screenshots) ===");
+            });
+        }
+
+        private static void LogAutoTestResponse(ScreenshotProcessingResponse response, long elapsedMs)
+        {
+            var ms = response.MatchState;
+            Logger.Log($"[AUTO-TEST] Response in {elapsedMs}ms:");
+            if (ms.BlueTeam != null)
+            {
+                Logger.Log($"[AUTO-TEST]   BLUE: T={ms.BlueTeam.Tank} D1={ms.BlueTeam.Damage1} D2={ms.BlueTeam.Damage2} S1={ms.BlueTeam.Support1} S2={ms.BlueTeam.Support2}");
+            }
+            if (ms.RedTeam != null)
+            {
+                Logger.Log($"[AUTO-TEST]   RED:  T={ms.RedTeam.Tank} D1={ms.RedTeam.Damage1} D2={ms.RedTeam.Damage2} S1={ms.RedTeam.Support1} S2={ms.RedTeam.Support2}");
+            }
+            if (ms.Map != MapName.MapUnspecified)
+            {
+                Logger.Log($"[AUTO-TEST]   Map: {ms.Map}");
+            }
+            if (ms.PlayerHero != HeroName.NameUnspecified)
+            {
+                Logger.Log($"[AUTO-TEST]   Player: {ms.PlayerHero}");
+            }
+            if (response.PersistedBlueTeamSlots.Count > 0)
+            {
+                Logger.Log($"[AUTO-TEST]   Persisted Blue: {string.Join(", ", response.PersistedBlueTeamSlots)}");
+            }
+            if (response.PersistedRedTeamSlots.Count > 0)
+            {
+                Logger.Log($"[AUTO-TEST]   Persisted Red: {string.Join(", ", response.PersistedRedTeamSlots)}");
             }
         }
 


### PR DESCRIPTION
## Summary

### Hero Persistence (supports owmeta PR #82)
- Send `previous_match_state` to backend so heroes persist when recognition fails
- Parse `persistedBlueTeamSlots` / `persistedRedTeamSlots` from API response
- Display light-blue "Updated (N heroes from memory)" indicator when slots are filled from memory
- Allow HIDDEN heroes through display filter for proper rendering

### Hotkey Flicker Fix
- Replace `RegisterHotKey` with low-level keyboard hook for F2/F3 toggle keys
- Track key-held state to prevent flickering from key repeat events

### Bug Fixes
- Add JetpackCat icon mapping for OverFast API