### PR TITLE
fix: reset HUD cache on map changes

### DIFF
--- a/Display/CompositionDashboard.xaml.cs
+++ b/Display/CompositionDashboard.xaml.cs
@@ -31,6 +31,26 @@ namespace Owmeta.Display
 
         private MapName? _currentMap;
 
+        public void Clear()
+        {
+            _currentMap = null;
+            BlueTeamPanel.Clear();
+            RedTeamPanel.Clear();
+            VulnerableTeammates.Clear();
+            DangerousEnemies.Clear();
+            TeamSwapSuggestions.Clear();
+            VulnerableSection.Visibility = Visibility.Collapsed;
+            DangerousSection.Visibility = Visibility.Collapsed;
+            TeamSwapSection.Visibility = Visibility.Collapsed;
+            MatchupText.Text = "NO DATA";
+            MatchupText.Foreground = EvenColor;
+
+            if (MatchupIcon != null)
+            {
+                MatchupIcon.Stroke = EvenColor;
+            }
+        }
+
         private void UpdateMatchupIndicator()
         {
             int blueScore = BlueTeamPanel.LastScore;

--- a/Display/DataFreshnessIndicator.xaml.cs
+++ b/Display/DataFreshnessIndicator.xaml.cs
@@ -66,6 +66,12 @@ namespace Owmeta.Display
             UpdateDisplay();
         }
 
+        public void Reset()
+        {
+            _lastUpdateTime = DateTime.MinValue;
+            UpdateDisplay();
+        }
+
         private void UpdateDisplay()
         {
             if (_lastUpdateTime == DateTime.MinValue)

--- a/Display/OverlayWindow.xaml.cs
+++ b/Display/OverlayWindow.xaml.cs
@@ -578,6 +578,12 @@ namespace Owmeta.Display
         {
             Dispatcher.Invoke(() =>
             {
+                bool knownMapChanged = MatchBoundaryPolicy.IsKnownMapChange(_matchState?.Map, response.MatchState.Map);
+                if (knownMapChanged)
+                {
+                    ResetAnalysisState($"map changed from {_matchState?.Map} to {response.MatchState.Map}");
+                }
+
                 _matchState = response.MatchState;
 
                 // Filter out Unknown/Hidden heroes, keeping only recognized ones
@@ -620,6 +626,11 @@ namespace Owmeta.Display
                 if (_blueTeamAnalysis != null && _redTeamAnalysis != null)
                 {
                     CompositionDashboard.Update(_blueTeamAnalysis, _redTeamAnalysis);
+                }
+
+                if (knownMapChanged && filteredBlue.Count == 0 && filteredRed.Count == 0)
+                {
+                    DataFreshnessIndicator.SetStatus("New match detected - capture again");
                 }
             });
         }
@@ -669,6 +680,21 @@ namespace Owmeta.Display
                 UpdateHotkeyRegistrations();
                 UpdateScreenshotHotkeyRegistration();
             });
+        }
+
+        private void ResetAnalysisState(string reason)
+        {
+            _matchState = null;
+            _blueTeamAnalysis = null;
+            _redTeamAnalysis = null;
+
+            BlueTeamPanel.Clear();
+            RedTeamPanel.Clear();
+            SwapSuggestionsPanel.Clear();
+            CompositionDashboard.Clear();
+            DataFreshnessIndicator.Reset();
+
+            Logger.Log($"HUD analysis cache reset: {reason}");
         }
 
         public void ToggleVisibility()

--- a/Display/SwapSuggestionsPanel.xaml.cs
+++ b/Display/SwapSuggestionsPanel.xaml.cs
@@ -21,6 +21,16 @@ namespace Owmeta.Display
             SuggestionsControl.ItemsSource = SwapSuggestions;
         }
 
+        public void Clear()
+        {
+            _currentHero = null;
+            _currentMap = null;
+            _blueTeamAnalysis = null;
+            CurrentHeroCard.DataContext = null;
+            CurrentHeroCard.Visibility = Visibility.Collapsed;
+            SwapSuggestions.Clear();
+        }
+
         public void UpdateSuggestions(HeroName playerHero, Dictionary<HeroName, HeroAnalysis> blueTeamAnalysis, MapName? currentMap = null)
         {
             try
@@ -34,6 +44,7 @@ namespace Owmeta.Display
                 // Update current hero
                 _currentHero = CreateHeroViewModel(playerHero, currentHeroAnalysis, true);
                 CurrentHeroCard.DataContext = _currentHero;
+                CurrentHeroCard.Visibility = Visibility.Visible;
 
                 // Update swap suggestions - sorted by score (highest first), filtered by min score, limited to 21
                 SwapSuggestions.Clear();

--- a/Display/TeamCompositionPanel.xaml.cs
+++ b/Display/TeamCompositionPanel.xaml.cs
@@ -88,6 +88,17 @@ namespace Owmeta.Display
             CompactList.ItemsSource = Compositions;
         }
 
+        public void Clear()
+        {
+            LastScore = 0;
+            Compositions.Clear();
+
+            var neutralColor = Color.FromRgb(0x9C, 0xA3, 0xAF);
+            TeamScoreText.Text = "--";
+            TeamScoreText.Foreground = new SolidColorBrush(neutralColor);
+            ScoreBadgeBackground.Color = Color.FromArgb(0x1A, neutralColor.R, neutralColor.G, neutralColor.B);
+        }
+
         public void UpdateCompositions(Dictionary<HeroName, HeroAnalysis> teamData)
         {
             if (teamData == null) return;

--- a/OwmetaHUD.csproj
+++ b/OwmetaHUD.csproj
@@ -20,6 +20,9 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
+    <Compile Remove="Tests\**\*.cs" />
+  </ItemGroup>
+  <ItemGroup>
     <Folder Include="Model\"/>
   </ItemGroup>
   <ItemGroup>

--- a/Services/MatchBoundaryPolicy.cs
+++ b/Services/MatchBoundaryPolicy.cs
@@ -1,0 +1,22 @@
+using Owmeta.Model;
+
+namespace Owmeta.Services
+{
+    public static class MatchBoundaryPolicy
+    {
+        public static bool IsKnownMapChange(MapName? previousMap, MapName? currentMap)
+        {
+            return previousMap.HasValue &&
+                   currentMap.HasValue &&
+                   IsKnownMap(previousMap.Value) &&
+                   IsKnownMap(currentMap.Value) &&
+                   previousMap.Value != currentMap.Value;
+        }
+
+        private static bool IsKnownMap(MapName map)
+        {
+            return map != MapName.MapUnspecified &&
+                   map != MapName.AllMaps;
+        }
+    }
+}

--- a/Tests/OWMetaHUD.Tests/OWMetaHUD.Tests.csproj
+++ b/Tests/OWMetaHUD.Tests/OWMetaHUD.Tests.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <UseWPF>true</UseWPF>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\OwmetaHUD.csproj" />
+  </ItemGroup>
+</Project>

--- a/Tests/OWMetaHUD.Tests/Program.cs
+++ b/Tests/OWMetaHUD.Tests/Program.cs
@@ -1,0 +1,54 @@
+using Owmeta.Model;
+using Owmeta.Services;
+
+var tests = new (string Name, Action Run)[]
+{
+    ("resets when previous and current known maps differ", () =>
+    {
+        AssertTrue(MatchBoundaryPolicy.IsKnownMapChange(MapName.KingsRow, MapName.Route66));
+    }),
+    ("does not reset when known maps are the same", () =>
+    {
+        AssertFalse(MatchBoundaryPolicy.IsKnownMapChange(MapName.KingsRow, MapName.KingsRow));
+    }),
+    ("does not reset when previous map is unspecified", () =>
+    {
+        AssertFalse(MatchBoundaryPolicy.IsKnownMapChange(MapName.MapUnspecified, MapName.Route66));
+    }),
+    ("does not reset when current map is unspecified", () =>
+    {
+        AssertFalse(MatchBoundaryPolicy.IsKnownMapChange(MapName.KingsRow, MapName.MapUnspecified));
+    }),
+};
+
+foreach (var test in tests)
+{
+    try
+    {
+        test.Run();
+        Console.WriteLine($"PASS {test.Name}");
+    }
+    catch (Exception ex)
+    {
+        Console.Error.WriteLine($"FAIL {test.Name}: {ex.Message}");
+        return 1;
+    }
+}
+
+return 0;
+
+static void AssertTrue(bool value)
+{
+    if (!value)
+    {
+        throw new Exception("expected true");
+    }
+}
+
+static void AssertFalse(bool value)
+{
+    if (value)
+    {
+        throw new Exception("expected false");
+    }
+}


### PR DESCRIPTION
## Summary
- reset HUD-local F2/F3 analysis caches when the detected map changes
- add a small match-boundary policy for known-map comparisons
- add regression coverage for map-boundary reset behavior

## Verification
- dotnet build OwmetaHUD.sln --no-restore
- dotnet run --project Tests/OWMetaHUD.Tests/OWMetaHUD.Tests.csproj --no-restore